### PR TITLE
List radio beacons when enabledRadioBeaconDrop is false.

### DIFF
--- a/CTLD.lua
+++ b/CTLD.lua
@@ -4562,6 +4562,9 @@ function ctld.addF10MenuOptions()
                             missionCommands.addCommandForGroup(_groupId, "List Beacons", _radioCommands, ctld.listRadioBeacons, { _unitName })
                             missionCommands.addCommandForGroup(_groupId, "Drop Beacon", _radioCommands, ctld.dropRadioBeacon, { _unitName })
                             missionCommands.addCommandForGroup(_groupId, "Remove Closet Beacon", _radioCommands, ctld.removeRadioBeacon, { _unitName })
+                        elseif ctld.deployedRadioBeacons ~= {} then
+                            local _radioCommands = missionCommands.addSubMenuForGroup(_groupId, "Radio Beacons", _rootPath)
+                            missionCommands.addCommandForGroup(_groupId, "List Beacons", _radioCommands, ctld.listRadioBeacons, { _unitName })
                         end
 
                         ctld.addedTo[tostring(_groupId)] = true


### PR DESCRIPTION
When radio beacons are programmatically generated, if the option to allow
the player to create beacons is not set then there was no way for the
player to get the operating frequency of the beacons.

This patch modifies addF10MenuOptions to give the user an option to list radio
beacons when enabledRadioBaconDrop is false.  If enabledRadioBeaconDrop
is true then there is no change to the behaviour of the program.

However if it is false then a check is made to see if
deployedRadioBeacons is empty.  If it is not the the user is given the
option to list radio beacons but not modify them.