### PR TITLE
Use transportLimit for unknown numberOrTemplate

### DIFF
--- a/CTLD.lua
+++ b/CTLD.lua
@@ -2121,7 +2121,7 @@ function ctld.loadTroops(_heli, _troops, _numberOrTemplate)
 
     --number doesnt apply to vehicles
     if _numberOrTemplate == nil  or (type(_numberOrTemplate) ~= "table" and type(_numberOrTemplate) ~= "number")  then
-        _numberOrTemplate = ctld.numberOfTroops
+        _numberOrTemplate = ctld.getTransportLimit(_heli:getTypeName())
     end
 
     if _onboard == nil then


### PR DESCRIPTION
Instead of directly using the numberOfTroops it should first check for the actual transport limit (if defined) for the given helo type. Otherwise the unitLoadLimits would be ignored for all AI flights automatically loading troops in pickup zones.

This allows to setup unitLoadLimits like this for example:

```
ctld.unitLoadLimits = {
    ["UH-1H"] = 6,
    ["Mi-8MT"] = 12,
    ---["UH-60L"] = 10,
}
```
AI UH-1H and MI-8s will only load the limits defined in this table. All other units for example the UH-60L will load the `ctld.numberOfTroops` instead as per default.