### PR TITLE
Make laser code start from 1512

### DIFF
--- a/CTLD.lua
+++ b/CTLD.lua
@@ -5868,7 +5868,7 @@ function ctld.generateLaserCode()
     ctld.jtacGeneratedLaserCodes = {}
 
     -- generate list of laser codes
-    local _code = 1111
+    local _code = 1511
 
     local _count = 1
 


### PR DESCRIPTION
for DCS F-14 compatibility: codes below 1511 are not allowed.
