### PR TITLE
JTAC Smoke Offset Config Options

### DIFF
--- a/CTLD.lua
+++ b/CTLD.lua
@@ -142,6 +142,10 @@ ctld.JTAC_smokeOn_BLUE = true -- enables marking of target with smoke for BLUE f
 ctld.JTAC_smokeColour_RED = 4 -- RED side smoke colour -- Green = 0 , Red = 1, White = 2, Orange = 3, Blue = 4
 ctld.JTAC_smokeColour_BLUE = 1 -- BLUE side smoke colour -- Green = 0 , Red = 1, White = 2, Orange = 3, Blue = 4
 
+ctld.JTAC_smokeOffset_x = 0.0 -- distance in the X direction from target to smoke (default 0.0)
+ctld.JTAC_smokeOffset_y = 2.0 -- distance in the Y direction from target to smoke (default 2.0)
+ctld.JTAC_smokeOffset_z = 0.0 -- distance in the z direction from target to smoke (default 0.0)
+
 ctld.JTAC_jtacStatusF10 = true -- enables F10 JTAC Status menu
 
 ctld.JTAC_location = true -- shows location of target in JTAC message
@@ -5619,7 +5623,7 @@ function ctld.createSmokeMarker(_enemyUnit, _colour)
 
     -- move smoke 2 meters above target for ease
     local _enemyPoint = _enemyUnit:getPoint()
-    trigger.action.smoke({ x = _enemyPoint.x, y = _enemyPoint.y + 2.0, z = _enemyPoint.z }, _colour)
+    trigger.action.smoke({ x = _enemyPoint.x + ctld.JTAC_smokeOffset_x, y = _enemyPoint.y + ctld.JTAC_smokeOffset_y, z = _enemyPoint.z + ctld.JTAC_smokeOffset_z }, _colour)
 end
 
 function ctld.cancelLase(_jtacGroupName)

--- a/README.md
+++ b/README.md
@@ -667,6 +667,10 @@ ctld.JTAC_smokeOn_BLUE = true -- enables marking of target with smoke for BLUE f
 ctld.JTAC_smokeColour_RED = 4 -- RED side smoke colour -- Green = 0 , Red = 1, White = 2, Orange = 3, Blue = 4
 ctld.JTAC_smokeColour_BLUE = 1 -- BLUE side smoke colour -- Green = 0 , Red = 1, White = 2, Orange = 3, Blue = 4
 
+ctld.JTAC_smokeOffset_x = 0.0 -- distance in the X direction from target to spawn smoke marker (default 0.0)
+ctld.JTAC_smokeOffset_y = 2.0 -- distance in the Y direction from target to spawn smoke marker (default 2.0)
+ctld.JTAC_smokeOffset_z = 0.0 -- distance in the z direction from target to spawn smoke marker (default 0.0)
+
 ctld.JTAC_jtacStatusF10 = false -- enables F10 JTAC Status menu
 
 ctld.JTAC_location = false -- shows location of target in JTAC message


### PR DESCRIPTION
Added JTAC configuration settings for the X, Y, and Z offsets of smoke markers for lased targets. This will enable the smoke to be configured to be off the target so as to not block the target from being visible in a TGP.