### PR TITLE
Add distance when Hercules spawned vehicules because they always collide

### DIFF
--- a/CTLD.lua
+++ b/CTLD.lua
@@ -64,13 +64,23 @@ ctld.numberOfTroops = 10 -- default number of troops to load on a transport heli
 ctld.enableFastRopeInsertion = true -- allows you to drop troops by fast rope
 ctld.fastRopeMaximumHeight = 18.28 -- in meters which is 60 ft max fast rope (not rappell) safe height
 
-ctld.vehiclesForTransportRED = { "BRDM-2", "BTR_D" } -- vehicles to load onto Il-76 - Alternatives {"Strela-1 9P31","BMP-1"}
-ctld.vehiclesForTransportBLUE = { "M1045 HMMWV TOW", "M1043 HMMWV Armament" } -- vehicles to load onto c130 - Alternatives {"M1128 Stryker MGS","M1097 Avenger"}
+ctld.vehiclesForTransportRED = { "BRDM-2", "BTR_D" } -- vehicles to load onto Il-76 
+--> Alternatives {"Strela-1 9P31","BMP-1"}
+--> Modern { "BTR_D", "Ural-375 ZU-23 Insurgent" }
+--> COLD WAR { "BMP-2", "Ural-375 ZU-23 Insurgent" }
+ctld.vehiclesForTransportBLUE = { "M1045 HMMWV TOW", "M1043 HMMWV Armament" } -- vehicles to load onto c130 
+--> Alternatives {"M1128 Stryker MGS","M1097 Avenger"}
+--> Modern { "M-2 Bradley", "Ural-375 ZU-23 Insurgent" }
+--> COLD WAR { "M-113", "Ural-375 ZU-23 Insurgent" }
 ctld.vehiclesWeight = {
     ["BRDM-2"] = 7000,
     ["BTR_D"] = 8000,
     ["M1045 HMMWV TOW"] = 3220,
-    ["M1043 HMMWV Armament"] = 2500
+    ["M1043 HMMWV Armament"] = 2500,
+    ["Ural-375 ZU-23 Insurgent"] = 9000,
+    ["M-2 Bradley"] = 15000,
+    ["BMP-2"] = 7000,
+    ["M-113"] = 7000,
 }
 
 ctld.aaLaunchers = 3 -- controls how many launchers to add to the kub/buk when its spawned.

--- a/CTLD.lua
+++ b/CTLD.lua
@@ -4222,7 +4222,7 @@ function ctld.spawnDroppedGroup(_point, _details, _spawnBehind, _maxSearch)
 
 
         for _i, _detail in ipairs(_details.units) do
-            _group.units[_i] = ctld.createUnit(_pos.x + (_xOffset + 10 * _i), _pos.z + (_yOffset + 10 * _i), _angle, _detail)
+            _group.units[_i] = ctld.createUnit(_pos.x + (_xOffset + 30 * _i), _pos.z + (_yOffset + 30 * _i), _angle, _detail)
         end
     end
 


### PR DESCRIPTION
When vehicules spawn from Hercules, they collide and damage the plane.

Add distance in 'function ctld.spawnDroppedGroup'
_xOffset + 10 >> _xOffset + 30

Add vehicules exemples to Hercules
in ctld.vehiclesForTransportRED
in ctld.vehiclesForTransportBLUE
in ctld.vehiclesWeight