### PR TITLE
Fixes and cleanup for multi-crate

### DIFF
--- a/CTLD.lua
+++ b/CTLD.lua
@@ -2857,12 +2857,12 @@ function ctld.checkHoverStatus()
                                 ctld.displayMessageToGroup(_transUnit, "Loaded  " .. _crate.details.desc .. " crate!", 10,true)
 
                                 --crates been moved once!
-                                ctld.crateMove[_crate] = nil
+                                ctld.crateMove[_crateUnitName] = nil
 
                                 if _transUnit:getCoalition() == 1 then
-                                    ctld.spawnedCratesRED[_crate] = nil
+                                    ctld.spawnedCratesRED[_crateUnitName] = nil
                                 else
-                                    ctld.spawnedCratesBLUE[_crate] = nil
+                                    ctld.spawnedCratesBLUE[_crateUnitName] = nil
                                 end
 
                                 _crate.crateUnit:destroy()


### PR DESCRIPTION
- Added comments for internalCargoLimits, remove the comment -- for a Unit to enable this option
- checkTransportStatus: inTransitSlingLoadCrates should be set to nil for a dead unit
- adaptWeightToCargo: Simplified variable initialization.  Removed cargoCapacity, not needed here.  Cleaned up construction of the output message.
- checkHoverStatus: Fixed the bug in "check transports" that prevented hover pickup.  Removed the encompassing "if _transUnit then" block, simplified variable initialization.  Removed local variables where the loop variables _name and _crate should have been used instead.
- loadNearbyCrate: Simplified variable initialization, cleaned up spacing.  Changed crateCapacity to cargoCapacity which was used previously.  Cleaned up construction of the output message.
- dropSlingCrate: Fixed the bug in "heightDiff > 40.0", the crate was not destroyed or removed from inTransitSlingLoadCrates. 
-  Cleaned up variable names and initialization.  