### PR TITLE
Set flags on loaded

### DIFF
--- a/CTLD-i18n.lua
+++ b/CTLD-i18n.lua
@@ -842,3 +842,6 @@ ctld.i18n["ko"]["ENABLE "] = "활성화 "
 ctld.i18n["ko"]["REQUEST "] = "요청 "
 ctld.i18n["ko"]["Reset TGT Selection"] = "TGT 선택 초기화"
 --========================================================================================================================
+
+trigger.action.setUserFlag("CTLD-i18n_Loaded", true)
+

--- a/CTLD.lua
+++ b/CTLD.lua
@@ -8712,3 +8712,5 @@ if ctld.dontInitialize then
 else
     ctld.initialize()
 end
+
+trigger.action.setUserFlag("CTLD_Loaded", true)

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ Optionaly, you can disable the STTS (text to speech over SRS) feature (4).
 
 First make sure MIST is loaded, either as an Initialization Script  for the mission or the first DO SCRIPT with a "TIME MORE" of 1. "TIME MORE" means run the actions after X seconds into the mission.
 
-If you want to make use of translations (internationalization features, a.k.a. "i18n"), you need to load the `CTLD-i18n.lua` script _before_ CTLD. Do this by adding a second trigger with a "TIME MORE" and a DO SCRIPT of `CTLD-i18n.lua`. 
+If you want to make use of translations (internationalization features, a.k.a. "i18n"), you need to load the `CTLD-i18n.lua` script _before_ CTLD. Do this by adding a second trigger with a "FLAG IS TRUE" for "MiST_Loaded" and a DO SCRIPT of `CTLD-i18n.lua`. 
 
-Load CTLD using a second (or third) trigger with a "TIME MORE" and a DO SCRIPT of `CTLD.lua`. 
+Load CTLD using a second (or third) trigger with a "FLAG IS TRUE" for "MiST_Loaded" (or "CTLD-i18n_Loaded") and a DO SCRIPT of `CTLD.lua`. 
 
 You will also need to load in **both** the **beacon.ogg** sound file and the **beaconsilent.ogg** for Radio beacon homing. This can be done by adding a two Sound To Country actions. Pick an unused country, like Australia so no one actually hears the audio when joining at the start of the mission. If you don't add the **two** Audio files, radio beacons will not work. Make sure not to rename the file as well.
 

--- a/mist.lua
+++ b/mist.lua
@@ -9595,6 +9595,7 @@ end
 
 -- initialize mist
 mist.init()
+trigger.action.setUserFlag("MiST_Loaded", true)
 env.info(('Mist version ' .. mist.majorVersion .. '.' .. mist.minorVersion .. '.' .. mist.build .. ' loaded.'))
 
 -- vim: noet:ts=2:sw=2


### PR DESCRIPTION
This allows loading scripts in order, using `FLAG IS TRUE` instead of `TIME AFTER`, which will allow each script to load immediately after the previous one is ready. I updated the README as well, but in general:

```yaml
- Trigger: Script Initialization
  Action: Do Script File
  File: mist.lua

- Trigger: FLAG IS TRUE
  Flag: MiST_Loaded
  Action: Do Script File
  File: ctld-i18n.lua

- Trigger: FLAG IS TRUE
  Flag: CTLD-i18n_Loaded
  Action: Do Script File
  File: ctld.lua
```

And then if `ctld.dontInitialize == true`:

```yaml
- Trigger: FLAG IS TRUE
  Flag: CTLD_Loaded
  Action: Do Script
  Script: ctld.initialize()
```

Though I did notice that `ctld.dontInitialize` isn't documented in the README, so that might need to be added as well, at some point.

I wasn't able to update the sample mission(s) because I don't have DCS working at the moment - I'm doing code for someone else's missions, and my laptop's drives are full, so it might be a while until I can access the mission editor.